### PR TITLE
Upgrade Gradle to Version `8.11.1` and Refactor Deprecated Code

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.jmailen.gradle.kotlinter.tasks.LintTask
 
+open class ExecOperationsTask @Inject constructor(@Internal val execOperations: ExecOperations) : DefaultTask()
+
 plugins {
     kotlin("jvm") version "1.9.0"
     application
@@ -38,7 +40,6 @@ tasks.getByName<Test>("test") {
     }
 }
 
-
 tasks.register<TestReportExam>("testReportExam")
 
 tasks.register<LintTask>("lint") {
@@ -52,27 +53,27 @@ tasks.register<LintTask>("lint") {
     )
 }
 
-tasks.register("runMainCriteriaTest") {
+tasks.register<ExecOperationsTask>("runMainCriteriaTest") {
     doFirst {
-        exec {
+        execOperations.exec {
             commandLine("gradle", "test")
             args("--tests", "ExamTestMain", "-q")
         }
     }
 }
 
-tasks.register("runOptionalCriteriaTest") {
+tasks.register<ExecOperationsTask>("runOptionalCriteriaTest") {
     doFirst {
-        exec {
+        execOperations.exec {
             commandLine("gradle", "test")
             args("--tests", "ExamTestOptional", "-q")
         }
     }
 }
 
-tasks.register("runAllTest") {
+tasks.register<ExecOperationsTask>("runAllTest") {
     doFirst {
-        exec {
+        execOperations.exec() {
             commandLine("gradle", "test")
             args("--continue", "-q")
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,7 @@ tasks.register<LintTask>("lint") {
 tasks.register<ExecOperationsTask>("runMainCriteriaTest") {
     doFirst {
         execOperations.exec {
-            commandLine("gradle", "test")
+            commandLine("./gradlew", "test")
             args("--tests", "ExamTestMain", "-q")
         }
     }
@@ -65,7 +65,7 @@ tasks.register<ExecOperationsTask>("runMainCriteriaTest") {
 tasks.register<ExecOperationsTask>("runOptionalCriteriaTest") {
     doFirst {
         execOperations.exec {
-            commandLine("gradle", "test")
+            commandLine("./gradlew", "test")
             args("--tests", "ExamTestOptional", "-q")
         }
     }
@@ -74,7 +74,7 @@ tasks.register<ExecOperationsTask>("runOptionalCriteriaTest") {
 tasks.register<ExecOperationsTask>("runAllTest") {
     doFirst {
         execOperations.exec() {
-            commandLine("gradle", "test")
+            commandLine("./gradlew", "test")
             args("--continue", "-q")
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "org.example"
-version = "2.1.3"
+version = "2.1.4"
 
 repositories {
     mavenCentral()

--- a/buildSrc/src/main/kotlin/TestReportExam.kt
+++ b/buildSrc/src/main/kotlin/TestReportExam.kt
@@ -90,7 +90,7 @@ abstract class TestReportExam : DefaultTask() {
 
     private fun writeFinalResult(finalResults: List<FinalResult>, fileName: String) {
         if (finalResults.isNotEmpty()) {
-            File(project.buildDir.toString() + "/test-results/test/$fileName.json").writeText(
+            File(project.layout.buildDirectory.toString() + "/test-results/test/$fileName.json").writeText(
                 GsonFactory.getGson().toJson(
                     finalResults
                 )
@@ -103,8 +103,8 @@ abstract class TestReportExam : DefaultTask() {
         /*
         * this path should be dynamic, so we can adjust test file name without touch this path again.
         * */
-        val mainTestResult = mappingTestResult("${project.buildDir}/test-results/test/TEST-ExamTestMain.xml")
-        val optionalTestResult = mappingTestResult("${project.buildDir}/test-results/test/TEST-ExamTestOptional.xml")
+        val mainTestResult = mappingTestResult("${project.layout.buildDirectory}/test-results/test/TEST-ExamTestMain.xml")
+        val optionalTestResult = mappingTestResult("${project.layout.buildDirectory}/test-results/test/TEST-ExamTestOptional.xml")
 
         val mainCriteriaFinalResult = getFinalResult(mainTestResult)
         val optionalCriteriaFinalResult = getFinalResult(optionalTestResult)
@@ -112,4 +112,4 @@ abstract class TestReportExam : DefaultTask() {
         writeFinalResult(finalResults = mainCriteriaFinalResult, fileName = "main-criteria-result")
         writeFinalResult(finalResults = optionalCriteriaFinalResult, fileName = "optional-criteria-result")
     }
-} 
+}

--- a/buildSrc/src/main/kotlin/TestReportExam.kt
+++ b/buildSrc/src/main/kotlin/TestReportExam.kt
@@ -90,7 +90,7 @@ abstract class TestReportExam : DefaultTask() {
 
     private fun writeFinalResult(finalResults: List<FinalResult>, fileName: String) {
         if (finalResults.isNotEmpty()) {
-            File(project.layout.buildDirectory.toString() + "/test-results/test/$fileName.json").writeText(
+            File(project.layout.buildDirectory.get().toString() + "/test-results/test/$fileName.json").writeText(
                 GsonFactory.getGson().toJson(
                     finalResults
                 )
@@ -103,8 +103,8 @@ abstract class TestReportExam : DefaultTask() {
         /*
         * this path should be dynamic, so we can adjust test file name without touch this path again.
         * */
-        val mainTestResult = mappingTestResult("${project.layout.buildDirectory}/test-results/test/TEST-ExamTestMain.xml")
-        val optionalTestResult = mappingTestResult("${project.layout.buildDirectory}/test-results/test/TEST-ExamTestOptional.xml")
+        val mainTestResult = mappingTestResult("${project.layout.buildDirectory.get()}/test-results/test/TEST-ExamTestMain.xml")
+        val optionalTestResult = mappingTestResult("${project.layout.buildDirectory.get()}/test-results/test/TEST-ExamTestOptional.xml")
 
         val mainCriteriaFinalResult = getFinalResult(mainTestResult)
         val optionalCriteriaFinalResult = getFinalResult(optionalTestResult)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
# Proposed Changes

- **Upgrade Gradle Version:**
 Update the Gradle version to 8.11.1 to leverage the latest features and improvements, as well as to ensure compatibility with newer Java versions.

- **Refactor Code:**
Refactor portions of the codebase to replace deprecated features and methods introduced in the new Gradle version. This ensures that the project remains up-to-date and maintains optimal functionality.